### PR TITLE
Fix duplicate definition warning

### DIFF
--- a/libraries/gem_installation.rb
+++ b/libraries/gem_installation.rb
@@ -1,15 +1,17 @@
 module GemInstallation
   module Dependencies
-    GEM_DEPENDENCIES = {
-      %w(fog bitlbee_config) => {
-        gems: %w(nokogiri)
-      },
-      "nokogiri" => {
-        %w(debian ubuntu) => {
-          "default" => %w(libxslt-dev libxml2-dev)
+    unless defined?(GEM_DEPENDENCIES)
+      GEM_DEPENDENCIES = {
+        %w(fog bitlbee_config) => {
+          gems: %w(nokogiri)
+        },
+        "nokogiri" => {
+          %w(debian ubuntu) => {
+            "default" => %w(libxslt-dev libxml2-dev)
+          }
         }
-      }
-    }.freeze
+      }.freeze
+    end
 
     def dependencies_for_gem(gem_name)
       if gem_dependencies.values.keys.include?(gem_name)


### PR DESCRIPTION
This fixes the warnings about duplicate definition of the constant.

Error was: 

```
gem_installation/libraries/gem_installation.rb:3: warning: previous definition of GEM_DEPENDENCIES was here
```
